### PR TITLE
Update SwitchTimeOpt.jl to Julia 1.6+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 *_build
 *.swp
+/Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,23 @@
+name = "SwitchTimeOpt"
+uuid = "eccdcdee-7c91-4511-9df1-90dbc05ba13b"
+authors = ["Bartolomeo Stellato and contributors"]
+version = "1.1.0"
+
+[deps]
+DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
+Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[compat]
+julia = "1"
+
+[extras]
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test", "SafeTestsets"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
 name = "SwitchTimeOpt"
-uuid = "eccdcdee-7c91-4511-9df1-90dbc05ba13b"
+uuid = "3eccecef-b58d-4dde-ac71-8ae5b669f823"
 authors = ["Bartolomeo Stellato and contributors"]
 version = "1.1.0"
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,0 @@
-julia 0.6
-MathProgBase
-DiffEqBase
-OrdinaryDiffEq
-Ipopt

--- a/examples/fishing.jl
+++ b/examples/fishing.jl
@@ -1,23 +1,22 @@
 using SwitchTimeOpt
+using MathOptInterface
+const MOI = MathOptInterface
 
-# Plotting settings
-using PyPlot, PyCall
-close("all")
-# Import seaborn for nice plots
-@pyimport seaborn as sns
-sns.set_palette("hls", 8)
-sns.set_context("paper", font_scale=1.5)
-sns.set_style("whitegrid")
-# Use Latex Labels in Plots
-plt[:rc]("text", usetex=true)
-plt[:rc]("font", family="serif")
-
-maxiter = 20
+using Plots
 using Ipopt
-solver = IpoptSolver(
-  print_level=0,
-  max_iter=maxiter)
 
+# Define Solver options
+maxiter = 100
+maxtime = 1000.0
+verbose = 5
+tolerance = 1e-06
+
+#Define solver
+solver = Ipopt.Optimizer()
+MOI.set(solver, MOI.RawOptimizerAttribute("tol"), tolerance)
+MOI.set(solver, MOI.RawOptimizerAttribute("print_level"), verbose)
+MOI.set(solver, MOI.RawOptimizerAttribute("max_cpu_time"), maxtime)
+MOI.set(solver, MOI.RawOptimizerAttribute("max_iter"), maxiter)
 
 ### Define system parameters
 # Time vector
@@ -28,18 +27,19 @@ tf = 12.0
 nx = 4
 
 # Integer input
-uvec = [repmat([0.0; 1.0], 4, 1); 0.0]'
+uvec = [repeat([0.0; 1.0], 3, 1); 0.0]
+uvec = copy(uvec')
 
 # Number of switching times
 N = size(uvec,2) - 1
 
 # Cost funcction matrix
-C = [1.0 0.0 -1.0 0.0;
-     0.0 1.0 0.0  -1.0]
+C = [1.0 0.0 -1.0;
+     0.0 1.0 -1.0]
 Q = C'*C
 
 # Define initial state
-x0 = [0.5; 0.7; 1; 1]
+x0 = [0.5; 0.7; 1]
 
 
 ### Define system dynamics
@@ -49,129 +49,40 @@ function nldyn(x::Array{Float64,1}, u::Array{Float64,1})
   f[1] = x[1] - x[1]*x[2] - 0.4*x[1]*u[1]
   f[2] = -x[2] + x[1]*x[2] - 0.2*x[2]*u[1]
   return f
-
 end
 
 function nldyn_deriv(x::Array{Float64,1}, u::Array{Float64,1})
-  df = [1.0-x[2]-0.4*u[1]       -x[1]                   0    0;
-        x[2]                     -1+x[1]-0.2*u[1]       0    0;
-        0                        0                      0    0;
-        0                        0                      0    0]
+  df = [1.0-x[2]-0.4*u[1]       -x[1]                   0;
+        x[2]                     -1+x[1]-0.2*u[1]       0;
+        0                        0                      0]
+  return df
 end
 
 
-### Generate and solve problems with different grid points
-ngrid = [100; 150; 200; 250]
+# Generate and solve problem
+ngrid = 100
 
+# Initialize the problem
+m = stoproblem( 
+  x0,                 # Initial state
+  nldyn,              # Nonlinear dynamics
+  nldyn_deriv,        # Nonlinear dynamics derivative
+  uvec,               # Vector of integer inputs
+  ngrid = ngrid,      # Number of grid points
+  t0 = t0,            # InitialtTime
+  tf = tf,            # Final time
+  Q = Q,              # Cost matrix
+  solver = solver)
 
-idx200 = (find(ngrid .== 200))[1]
+solve!(m)
+objlin = getobjval(m)
+tauopt = gettau(m)
+status = getstat(m)
+xsim, xpts, objode45, t = simulate(m, tauopt)
 
-# Preallocate vectors for results
-objode45 = Array{Float64}(length(ngrid))
-objlin = Array{Float64}(length(ngrid))
-objiterates = Array{Float64}(maxiter+1, length(ngrid))
-cputime = Array{Float64}(length(ngrid))
-nobjeval = Array{Int}(length(ngrid))
-ngradeval = Array{Int}(length(ngrid))
-nhesseval = Array{Int}(length(ngrid))
-tauopt = Array{Float64}(N, length(ngrid))
-xsim = Array{Float64}(4, 10^4, length(ngrid))
-xlinsim = Array{Float64}(4, 10^4, length(ngrid))
-usim = Array{Float64}(1, 10^4, length(ngrid))
+println("Status: ", status)
+println("Objective value: ", objlin)
 
-# Initialize the problem first
-m = stoproblem(x0, nldyn, nldyn_deriv, uvec)
-
-for i = 1:length(ngrid)  # Iterate over all grid points numbers
-
-  m = stoproblem(
-    x0,                 # Initial state
-    nldyn,              # Nonlinear dynamics
-    nldyn_deriv,        # Nonlinear dynamics derivative
-    uvec,               # Vector of integer inputs
-    ngrid = ngrid[i],   # Number of grid points
-    t0 = t0,            # Initial time
-    tf = tf,            # Final time
-    Q = Q,              # Cost matrix
-    solver = solver)
-
-  # Solve optimization
-  solve!(m)
-
-  # Obtain values
-  tauopt[:, i] = gettau(m)
-  objlin[i] = getobjval(m)
-  cputime[i] = getsoltime(m)
-  nobjeval[i] = getnobjeval(m)
-  ngradeval[i] = getngradeval(m)
-  nhesseval[i] = getnhesseval(m)
-
-  # Simulate system
-  # Nonlinear simulation
-  xsim[:, :, i], xpts, objode45[i], t = simulate(m, tauopt[:, i])
-  usim[:, :, i], _ = simulateinput(m, t)
-
-  # Linearized simulation
-  xlinsim[:, :, i], _, Jlinsim, _ = simulatelinearized(m, tauopt[:, i], t)
-
-  # Save objective function iterates
-  objiterates[:, i] = m.STOev.obj[2:end]
-
-end
-
-
-###  Print results
-@printf("RESULTS\n")
-@printf("-------\n\n")
-
-@printf("+==================================================================================+\n")
-@printf("|  ngrid   |   objode45  |   objlin    | deltaobj [%%] |  nobjeval  |  cputime [s]  |\n")
-@printf("+==================================================================================+\n")
-
-
-for i = 1:length(ngrid)
-  @printf("|  %7.i | %9.4f   | %9.4f   |   %6.3f     | %9.i  | %12.4f  | \n", ngrid[i], objode45[i], objlin[i], 100*norm(objode45[i]- objlin[i])/objode45[i], nobjeval[i], cputime[i])
-  @printf("+----------------------------------------------------------------------------------+\n")
-end
-
-
-
-@printf("\nOptimal Switching Times for ngrid = 200\n")
-@printf("--------------------------------------\n")
-@printf("tauopt = "); show(round.(tauopt[:, idx200],3)); @printf("\n")
-
-
-# Generate plots for ngrid = 25
-t = linspace(t0, tf, 10000)
-
-figure()
-subplot(3,1,1)
-plot(t, xlinsim[1,:, idx200], sns.xkcd_rgb["grass green"], linestyle = "dashdot")
-plot(t, xsim[1,:, idx200], sns.xkcd_rgb["denim blue"])
-ylim(0, 1.75)
-yticks([0; 1; ])
-ylabel(L"x_1")
-
-subplot(3,1,2)
-plot(t, xlinsim[2,:, idx200], sns.xkcd_rgb["grass green"], linestyle = "dashdot")
-plot(t, xsim[2, :, idx200], sns.xkcd_rgb["denim blue"])
-ylabel(L"x_2")
-ylim(0, 1.75)
-yticks([0; 1; ])
-
-subplot(3,1,3)
-plot(t, usim[1,:, idx200], sns.xkcd_rgb["denim blue"])
-ylim(-0.2, 1.2)
-yticks([0; 1])
-ylabel(L"u")
-xlabel(L"$\mathrm{Time}\; [s]$")
-
-# Save figure
-# tight_layout()
-# savefig("fishing_problem.pdf")
-
-
-
-
-# Do not return anything
-nothing
+showPlots = true
+savePlots = false
+plotSolution(m, "Lotka-Volterra", "Lotka-Volterra", showPlots, savePlots)

--- a/examples/fishing.jl
+++ b/examples/fishing.jl
@@ -1,8 +1,6 @@
 using SwitchTimeOpt
 using MathOptInterface
 const MOI = MathOptInterface
-
-using Plots
 using Ipopt
 
 # Define Solver options
@@ -23,11 +21,8 @@ MOI.set(solver, MOI.RawOptimizerAttribute("max_iter"), maxiter)
 t0 = 0.0
 tf = 12.0
 
-# Size of the system
-nx = 4
-
 # Integer input
-uvec = [repeat([0.0; 1.0], 3, 1); 0.0]
+uvec = [repeat([0.0; 1.0], 4, 1); 0.0] 
 uvec = copy(uvec')
 
 # Number of switching times
@@ -60,7 +55,7 @@ end
 
 
 # Generate and solve problem
-ngrid = 100
+ngrid = 300
 
 # Initialize the problem
 m = stoproblem( 

--- a/examples/linear.jl
+++ b/examples/linear.jl
@@ -60,13 +60,11 @@ soltime = getsoltime(m)
 
 # Simulate linear system
 xsim, xpts, Jsim, t = simulate(m)
-
 println("Objective: ", Jsim)
 
-p1 = plot(title="Linear example", titlefont=font(10))
-for i=1:nx
-  plot!(t, xsim[i,:], label="x"*string(i))
+uvec = zeros(2,N+1)
+for i=1:N+1
+  uvec[mod(i+1,2)+1,i] = 1
 end
-plot!(grid=true, ylim=[(1-0.2*sign(minimum(xsim)))*minimum(xsim), (1+0.2*sign(maximum(xsim)))*maximum(xsim)])
-display(plot(p1))
 
+plotSolution(m, uvec, "Linear example", "Linear example", true, false)

--- a/examples/tank.jl
+++ b/examples/tank.jl
@@ -1,26 +1,23 @@
 
 using SwitchTimeOpt
+using MathOptInterface
+const MOI = MathOptInterface
 
-# Plotting
-using PyPlot, PyCall
-close("all")
-# Import Seaborn for nice plots
-@pyimport seaborn as sns
-sns.set_palette("hls", 8)
-sns.set_context("paper", font_scale=1.5)
-sns.set_style("whitegrid")
-# Use Latex Labels in Plots
-plt[:rc]("text", usetex=true)
-plt[:rc]("font", family="serif")   # Use Serif math
-
-
-maxiter = 15
+using Plots
 using Ipopt
-solver = IpoptSolver(
-  print_level=0,
-  tol = 1e-10,  # Increase required precision to avoid convergence before maxiter iterations
-  max_iter = maxiter)
 
+# Define Solver options
+maxiter = 300
+maxtime = 1000.0
+verbose = 5
+tolerance = 1e-06
+
+#Define solver
+solver = Ipopt.Optimizer()
+MOI.set(solver, MOI.RawOptimizerAttribute("tol"), tolerance)
+MOI.set(solver, MOI.RawOptimizerAttribute("print_level"), verbose)
+MOI.set(solver, MOI.RawOptimizerAttribute("max_cpu_time"), maxtime)
+MOI.set(solver, MOI.RawOptimizerAttribute("max_iter"), maxiter)
 
 ### Define system parameters
 #  Time vector
@@ -28,7 +25,8 @@ t0 = 0.0
 tf = 10.0
 
 # Integer inputs
-uvec = repmat([1.0; 2.0], 8, 1)'
+uvec = repeat([1.0; 2.0], 8, 1)
+uvec = copy(uvec')
 
 # Number of switches
 N = size(uvec,2) -1
@@ -63,122 +61,30 @@ end
 
 
 
-# Generate and solve problems with different grid points
-ngrid = [10; 30; 50; 100]
+# Generate and solve problem
+ngrid = 100
 
+# Initialize the problem
+m = stoproblem( 
+  x0,                 # Initial state
+  nldyn,              # Nonlinear dynamics
+  nldyn_deriv,        # Nonlinear dynamics derivative
+  uvec,               # Vector of integer inputs
+  ngrid = ngrid,      # Number of grid points
+  t0 = t0,            # InitialtTime
+  tf = tf,            # Final time
+  Q = Q,              # Cost matrix
+  solver = solver)
 
-# Preallocate vectors for results
-objode45 = Array{Float64}(length(ngrid))
-objlin = Array{Float64}(length(ngrid))
-objiterates = Array{Float64}(maxiter+1, length(ngrid))
-cputime = Array{Float64}(length(ngrid))
-nobjeval = Array{Int}(length(ngrid))
-ngradeval = Array{Int}(length(ngrid))
-nhesseval = Array{Int}(length(ngrid))
-tauopt = Array{Float64}(N, length(ngrid))
-xsim = Array{Float64}(3, 10^4, length(ngrid))
-xlinsim = Array{Float64}(3, 10^4, length(ngrid))
-usim = Array{Float64}(1, 10^4, length(ngrid))
+solve!(m)
+objlin = getobjval(m)
+tauopt = gettau(m)
+status = getstat(m)
+xsim, xpts, objode45, t = simulate(m, tauopt)
 
-# Initialize the problem first
-m = stoproblem(x0, nldyn, nldyn_deriv, uvec)
+println("Status: ", status)
+println("Objective value: ", objlin)
 
-
-for i = 1:length(ngrid) # Iterate over all grid points numbers
-  m = stoproblem(
-    x0,                 # Initial state
-    nldyn,              # Nonlinear dynamics
-    nldyn_deriv,        # Nonlinear dynamics derivative
-    uvec,               # Vector of integer inputs
-    ngrid = ngrid[i],   # Number of grid points
-    t0 = t0,            # InitialtTime
-    tf = tf,            # Final time
-    Q = Q,              # Cost matrix
-    solver = solver)
-
-
-  # Solve optimization
-  solve!(m)
-
-  # Obtain values
-  tauopt[:, i] = gettau(m)
-  objlin[i] = getobjval(m)
-  cputime[i] = getsoltime(m)
-  nobjeval[i] = getnobjeval(m)
-  ngradeval[i] = getngradeval(m)
-  nhesseval[i] = getnhesseval(m)
-
-
-  # Simulate System
-  # Nonlinear Simulation
-  xsim[:, :, i], xpts, objode45[i], t = simulate(m, tauopt[:, i])
-  usim[:, :, i], _ = simulateinput(m, t)
-
-  # Linearized simulation
-  xlinsim[:, :, i], _, Jlinsim, _ = simulatelinearized(m, tauopt[:, i], t)
-
-  # Save objective iterates
-  objiterates[:, i] = m.STOev.obj[2:end]
-
-end
-
-
-
-###  Print results
-@printf("RESULTS\n")
-@printf("-------\n\n")
-
-@printf("+==================================================================================+\n")
-@printf("|  ngrid   |   objode45  |   objlin    | deltaobj [%%] |  nobjeval  |  cputime [s]  |\n")
-@printf("+==================================================================================+\n")
-
-
-for i = 1:length(ngrid)
-  @printf("|  %7.i | %9.4f   | %9.4f   |   %6.3f     | %9.i  | %12.4f  | \n", ngrid[i], objode45[i], objlin[i], 100*norm(objode45[i]- objlin[i])/objode45[i], nobjeval[i], cputime[i])
-  @printf("+----------------------------------------------------------------------------------+\n")
-end
-
-
-
-@printf("\nOptimal Switching Times for ngrid = 10\n")
-@printf("--------------------------------------\n")
-@printf("tauopt = "); show(round.(tauopt[:, 1],2)); @printf("\n")
-
-
-
-# Generate plots for ngrid = 10
-t = linspace(t0, tf, 10000)
-
-figure()
-subplot(3,1,1)
-plot(t, xlinsim[1,:, 1], sns.xkcd_rgb["grass green"], linestyle = "dashdot")
-plot(t, xsim[1,:, 1], sns.xkcd_rgb["denim blue"])
-ylim(1.5, 4)
-yticks([2; 3])
-ylabel(L"x_1")
-
-
-subplot(3,1,2)
-plot(t, xsim[3,:, 1], sns.xkcd_rgb["black"], linestyle = "dotted")
-plot(t, xlinsim[2,:, 1], sns.xkcd_rgb["grass green"], linestyle = "dashdot")
-plot(t, xsim[2,:, 1], sns.xkcd_rgb["denim blue"])
-ylabel(L"x_2")
-ylim(1.5, 4.0)
-yticks([2; 3])
-
-subplot(3,1,3)
-ax1 = plot(t, usim[1,:, 1], sns.xkcd_rgb["denim blue"])
-ylim(0.8, 2.2)
-yticks([1; 2])
-ax = gca()
-ax[:set_yticklabels]([L"u_{\mathrm{min}}", L"u_{\mathrm{max}}"])
-ylabel(L"u")
-xlabel(L"$\mathrm{Time}\; [s]$")
-
-## Save figure
-# tight_layout()
-# savefig("tank_problem.pdf")
-
-
-# Do not return anything
-nothing
+showPlots = true
+savePlots = false
+plotSolution(m, "Tank", "Tank", showPlots, savePlots)

--- a/src/SwitchTimeOpt.jl
+++ b/src/SwitchTimeOpt.jl
@@ -1,30 +1,24 @@
 module SwitchTimeOpt
 
-  # Import Necessary Modules
-  using MathOptInterface
-  using DiffEqBase
-  using OrdinaryDiffEq
-  using Ipopt
-  using LinearAlgebra
-  using SparseArrays
-  using Plots
+# Import Necessary Modules
+using MathOptInterface
+using DiffEqBase
+using OrdinaryDiffEq
+using Ipopt
+using LinearAlgebra
+using SparseArrays
+using Plots
 
 
-  export stoproblem,
-         setwarmstart!,setx0!,
-         solve!,
-         gettau,
-         getdelta,
-         gettaucomplete, getdeltacomplete,
-         getobjval, getstat, getsoltime,
-         getnobjeval, getngradeval, getnhesseval,
-         simulatelinearized, simulateinput,
-         simulate, plotSolution
+export stoproblem, setwarmstart!, setx0!, solve!
+export gettau, getdelta, gettaucomplete, getdeltacomplete, getobjval, getstat
+export getsoltime, getnobjeval, getngradeval, getnhesseval
+export simulatelinearized, simulateinput, simulate, plotSolution
 
-  # Include Source Files
-  include("types.jl")
-  include("interface.jl")
-  include("nlp.jl")
-  include("simulation.jl")
+# Include Source Files
+include("types.jl")
+include("interface.jl")
+include("nlp.jl")
+include("simulation.jl")
 
 end

--- a/src/SwitchTimeOpt.jl
+++ b/src/SwitchTimeOpt.jl
@@ -1,10 +1,13 @@
 module SwitchTimeOpt
 
   # Import Necessary Modules
-  using MathProgBase
+  using MathOptInterface
   using DiffEqBase
   using OrdinaryDiffEq
   using Ipopt
+  using LinearAlgebra
+  using SparseArrays
+  using Plots
 
 
   export stoproblem,
@@ -16,7 +19,7 @@ module SwitchTimeOpt
          getobjval, getstat, getsoltime,
          getnobjeval, getngradeval, getnhesseval,
          simulatelinearized, simulateinput,
-         simulate
+         simulate, plotSolution
 
   # Include Source Files
   include("types.jl")

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -372,7 +372,7 @@ function delta2tau(delta::Array{Float64, 1}, t0::Float64)
 end
 
 
-function plotSolution(d::STO, savename::String, title::String, show=true, save=false)
+function plotSolution(d::nlinSTO, savename::String, title::String, show=true, save=false)
 
   tauopt = gettau(d)
   xsim, ~, ~, t = simulate(d, tauopt)
@@ -391,9 +391,45 @@ function plotSolution(d::STO, savename::String, title::String, show=true, save=f
 
   p2 = plot()
   for i=1:n_omega
-    plot!(t,usim[i,:], label="u"*string(i), drawstyle="steps-pre")
+    plot!(t,usim[i,:], label="u"*string(i), linetype=:steppre)
   end
   plot!(ylim=[(1-0.2*sign(minimum(xsim)))*minimum(usim), (1+0.2*sign(maximum(xsim)))*maximum(usim)], grid=true, xlabel="time")
+  
+  if show && save
+    display(plot(p1, p2, layout=l))
+    savefig(savename*".pdf")
+  elseif save && !show
+    plot(p1, p2, layout=l)
+    savefig(savename*".pdf")
+  elseif !save && show
+    display(plot(p1, p2, layout=l))
+  end
+  return
+end
+
+function plotSolution(d::linSTO, u::Array{Float64,2}, savename::String, title::String, show=true, save=false)
+
+  tauopt = gettau(d)
+  xsim, ~, ~, t = simulate(d, tauopt)
+  println(length(t))
+  n_omega = size(u)[1]
+  nx = d.STOev.nx
+  # Plot solution
+  l = @layout [a;b]
+  p1 = plot(title=title, titlefont=font(10))
+  for i=1:nx
+    plot!(t, xsim[i,:], label="x"*string(i))
+  end
+  plot!(grid=true, ylim=[(1-0.2*sign(minimum(xsim)))*minimum(xsim), (1+0.2*sign(maximum(xsim)))*maximum(xsim)])
+
+  p2 = plot()
+  tSwitch = [d.STOev.t0; tauopt; d.STOev.tf]
+  println(length(tSwitch))
+  println(length([u[1,1]; u[1,:]]))
+  for i=1:n_omega
+    plot!(tSwitch, [u[i,1]; u[i,:]], label="A"*string(i), linetype=:steppre)
+  end
+  plot!(ylim=[(1-0.2*sign(minimum(xsim)))*minimum(u), (1+0.2*sign(maximum(xsim)))*maximum(u)], grid=true, xlabel="time")
   
   if show && save
     display(plot(p1, p2, layout=l))

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,141 +1,141 @@
 # Create STO Problem
 function stoproblem(
-  x0::Array{Float64,1},                 # Initial State
-  A::Array{Float64,3};                  # Linear Dynamics
-  ngrid::Int64=2,                       # Number of Linearization points in the fixed grid (2 for linear case. We do not need them by default)
-  t0::Float64=0.0,                      # Initial Time
-  tf::Float64=1.0,                      # Final Time
-  Q::Array{Float64, 2}=emptyfmat,       # Cost Matrix
-  E::Array{Float64, 2}=emptyfmat,      # Final Cost Matrix
-  lb::Array{Float64, 1}=emptyfvec,      # Lower Bound on Intervals
-  ub::Array{Float64, 1}=emptyfvec,      # Upper Bound on Intervals
-  tau0ws::Array{Float64,1}=emptyfvec,   # Warm Start tau vector
-  solver::MathOptInterface.AbstractOptimizer=Ipopt.Optimizer())
+    x0::Array{Float64,1},                 # Initial State
+    A::Array{Float64,3};                  # Linear Dynamics
+    ngrid::Int64=2,                       # Number of Linearization points in the fixed grid (2 for linear case. We do not need them by default)
+    t0::Float64=0.0,                      # Initial Time
+    tf::Float64=1.0,                      # Final Time
+    Q::Array{Float64, 2}=emptyfmat,       # Cost Matrix
+    E::Array{Float64, 2}=emptyfmat,      # Final Cost Matrix
+    lb::Array{Float64, 1}=emptyfvec,      # Lower Bound on Intervals
+    ub::Array{Float64, 1}=emptyfvec,      # Upper Bound on Intervals
+    tau0ws::Array{Float64,1}=emptyfvec,   # Warm Start tau vector
+    solver::MathOptInterface.AbstractOptimizer=Ipopt.Optimizer())
 
-  # Get Dimensions
-  nx = size(A, 1)      # State Dimension
-  N = size(A, 3) - 1   # Get number of switches
+    # Get Dimensions
+    nx = size(A, 1)      # State Dimension
+    N = size(A, 3) - 1   # Get number of switches
 
-  # Adjust variables which have not been initalized
-  if isempty(Q)
-    Q = 1.0 * Matrix(I, nx, nx)
-  end
-
-  if isempty(E)
-    E = zeros(nx, nx)
-  end
-
-  if isempty(lb)
-    lb = zeros(N+1)
-  end
-
-  if isempty(ub)
-    ub = Inf*ones(N+1)
-  end
-
-  if isempty(tau0ws)
-    tau0ws = collect(range(t0, stop=tf, length=N+2))
-    tau0ws = tau0ws[2:end-1]
-  end
-
-  # Define warm starting delta0
-  delta0ws = tau2delta(tau0ws, t0, tf)
-
-  # Create Discretization Grid
-  tgrid = collect(range(t0, stop=tf, length=ngrid))
-
-  # Initialize time vectors
-  tvec = Array{Float64}(undef, N + ngrid)    # Complete grid
-  tauIdx = Array{Int}(undef, N + 2)      # Indeces of switching times in the complete grid
-  tgridIdx = Array{Int}(undef, ngrid)      # Indeces of switching times in the complete grid
-  deltacomplete = Array{Float64}(undef, N + ngrid - 1)   # Intervals over the whole grid
-
-
-  ### Initialize NLP Evaluator
-  # Preallocate arrays
-  deltafun_prev = Array{Float64}(undef, N+1)
-  deltagrad_prev = Array{Float64}(undef, N+1)
-  deltahess_prev = Array{Float64}(undef, N+1)
-  xpts = Array{Float64}(undef, nx, N+ngrid); xpts[:, 1] = x0   # Set Initial State
-  expMat = Array{Float64}(undef, nx, nx, N+ngrid-1)
-  Phi = Array{Float64}(undef, nx, nx, N+2, N+2)
-  M = Array{Float64}(undef, nx, nx, N+ngrid-1)
-  S = Array{Float64}(undef, nx, nx, N+ngrid)
-  C = Array{Float64}(undef, nx, nx, N+1)
-
-  # Decompose Dynamics Matrices
-  V = Array{Complex{Float64}}(undef, 2*nx, 2*nx, N+1)
-  invV = Array{Complex{Float64}}(undef, 2*nx, 2*nx, N+1)
-  D =  Array{Complex{Float64}}(undef, 2*nx, N+1)
-  isDiag = Array{Bool}(undef, N+1)
-
-  for i = 1:N+1
-    D[:, i], V[:, :, i] = eigen([-A[:, :, i]'  Q;
-                             zeros(nx, nx) A[:, :, i]])
-    if cond(V[:, :, i]) == Inf  # Non diagonalizable matrix
-      isDiag[i] = false
-    else
-      invV[:, :, i] = inv(V[:, :, i])
-      isDiag[i] = true
+    # Adjust variables which have not been initalized
+    if isempty(Q)
+        Q = 1.0 * Matrix(I, nx, nx)
     end
-  end
+
+    if isempty(E)
+        E = zeros(nx, nx)
+    end
+
+    if isempty(lb)
+        lb = zeros(N+1)
+    end
+
+    if isempty(ub)
+        ub = Inf*ones(N+1)
+    end
+
+    if isempty(tau0ws)
+        tau0ws = collect(range(t0, stop=tf, length=N+2))
+        tau0ws = tau0ws[2:end-1]
+    end
+
+    # Define warm starting delta0
+    delta0ws = tau2delta(tau0ws, t0, tf)
+
+    # Create Discretization Grid
+    tgrid = collect(range(t0, stop=tf, length=ngrid))
+
+    # Initialize time vectors
+    tvec = Array{Float64}(undef, N + ngrid)    # Complete grid
+    tauIdx = Array{Int}(undef, N + 2)      # Indeces of switching times in the complete grid
+    tgridIdx = Array{Int}(undef, ngrid)      # Indeces of switching times in the complete grid
+    deltacomplete = Array{Float64}(undef, N + ngrid - 1)   # Intervals over the whole grid
 
 
-  # Construct Matrix of Indeces for lower triangular Matrix (Hessian)
-  IndTril = (LinearIndices(tril(ones(N+1, N+1))))[findall(!iszero,tril(ones(N+1, N+1)))]
-  Itril, Jtril, _ = begin
-  I_temp = findall(!iszero, tril(ones(N+1, N+1)))
-  (getindex.(I_temp, 1), getindex.(I_temp, 2), tril(ones(N+1, N+1))[I_temp])
-  end
+    ### Initialize NLP Evaluator
+    # Preallocate arrays
+    deltafun_prev = Array{Float64}(undef, N+1)
+    deltagrad_prev = Array{Float64}(undef, N+1)
+    deltahess_prev = Array{Float64}(undef, N+1)
+    xpts = Array{Float64}(undef, nx, N+ngrid); xpts[:, 1] = x0   # Set Initial State
+    expMat = Array{Float64}(undef, nx, nx, N+ngrid-1)
+    Phi = Array{Float64}(undef, nx, nx, N+2, N+2)
+    M = Array{Float64}(undef, nx, nx, N+ngrid-1)
+    S = Array{Float64}(undef, nx, nx, N+ngrid)
+    C = Array{Float64}(undef, nx, nx, N+1)
 
-  # Construct Constraints Matrix (Vector)
-  Ag = ones(1, N+1)
-  Ig, Jg, Vg = begin
+    # Decompose Dynamics Matrices
+    V = Array{Complex{Float64}}(undef, 2*nx, 2*nx, N+1)
+    invV = Array{Complex{Float64}}(undef, 2*nx, 2*nx, N+1)
+    D =  Array{Complex{Float64}}(undef, 2*nx, N+1)
+    isDiag = Array{Bool}(undef, N+1)
+
+    for i = 1:N+1
+    D[:, i], V[:, :, i] = eigen([-A[:, :, i]'  Q;
+                                zeros(nx, nx) A[:, :, i]])
+    if cond(V[:, :, i]) == Inf  # Non diagonalizable matrix
+        isDiag[i] = false
+    else
+        invV[:, :, i] = inv(V[:, :, i])
+        isDiag[i] = true
+    end
+    end
+
+
+    # Construct Matrix of Indeces for lower triangular Matrix (Hessian)
+    IndTril = (LinearIndices(tril(ones(N+1, N+1))))[findall(!iszero,tril(ones(N+1, N+1)))]
+    Itril, Jtril, _ = begin
+    I_temp = findall(!iszero, tril(ones(N+1, N+1)))
+    (getindex.(I_temp, 1), getindex.(I_temp, 2), tril(ones(N+1, N+1))[I_temp])
+    end
+
+    # Construct Constraints Matrix (Vector)
+    Ag = ones(1, N+1)
+    Ig, Jg, Vg = begin
     I_temp = findall(!iszero, Ag)
     (getindex.(I_temp, 1), getindex.(I_temp, 2), Ag[I_temp])
-  end
-  bg = [tf]   # Only one constraint for the sum of the switching intervals
+    end
+    bg = [tf]   # Only one constraint for the sum of the switching intervals
 
 
-  # Initialize objective evaluator
-  obj = Array{Float64}(undef, 0)
-  deltaval = Array{Float64}(undef, N+1, 0)
-  nobjeval = 0                           # Number of objective function evaluations
-  ngradeval = 0                           # Number of gradient evaluations
-  nhesseval = 0                           # Number of hessian evaluations
+    # Initialize objective evaluator
+    obj = Array{Float64}(undef, 0)
+    deltaval = Array{Float64}(undef, N+1, 0)
+    nobjeval = 0                           # Number of objective function evaluations
+    ngradeval = 0                           # Number of gradient evaluations
+    nhesseval = 0                           # Number of hessian evaluations
 
-  # Construct NLP evaluator
-  STOev = linSTOev(x0, nx, A, N, t0, tf, tf, Q, E, ngrid, tgrid, tvec,
-          tauIdx, tgridIdx, deltacomplete, V, invV, D, isDiag, IndTril,
-          Itril, Jtril, Ag, Ig, Jg, Vg, bg, deltafun_prev, deltagrad_prev,
-          deltahess_prev, xpts, expMat, Phi, M, S, C,
-          obj, deltaval, nobjeval, ngradeval, nhesseval)
+    # Construct NLP evaluator
+    STOev = linSTOev(x0, nx, A, N, t0, tf, tf, Q, E, ngrid, tgrid, tvec,
+            tauIdx, tgridIdx, deltacomplete, V, invV, D, isDiag, IndTril,
+            Itril, Jtril, Ag, Ig, Jg, Vg, bg, deltafun_prev, deltagrad_prev,
+            deltahess_prev, xpts, expMat, Phi, M, S, C,
+            obj, deltaval, nobjeval, ngradeval, nhesseval)
 
 
-model = solver
-MathOptInterface.empty!(model)
-delta = MathOptInterface.add_variables(model, N+1)
-for w_i in delta
-  MathOptInterface.add_constraint(model, w_i, MathOptInterface.GreaterThan(0.0))
-  MathOptInterface.add_constraint(model, w_i, MathOptInterface.LessThan(tf))
-end
+    model = solver
+    #MathOptInterface.empty!(model)
+    delta = MathOptInterface.add_variables(model, N+1)
+    for w_i in delta
+    MathOptInterface.add_constraint(model, w_i, MathOptInterface.GreaterThan(0.0))
+    MathOptInterface.add_constraint(model, w_i, MathOptInterface.LessThan(tf))
+    end
 
-lbub = [MathOptInterface.NLPBoundsPair(tf, tf)]
-MathOptInterface.set(model, MathOptInterface.VariablePrimalStart(), delta, delta0ws)
-block_data = MathOptInterface.NLPBlockData(
-  lbub,
-  STOev,
-  true
-)
-MathOptInterface.set(model, MathOptInterface.NLPBlock(), block_data)
-MathOptInterface.set(model, MathOptInterface.ObjectiveSense(), MathOptInterface.MIN_SENSE)
+    lbub = [MathOptInterface.NLPBoundsPair(tf, tf)]
+    MathOptInterface.set(model, MathOptInterface.VariablePrimalStart(), delta, delta0ws)
+    block_data = MathOptInterface.NLPBlockData(
+    lbub,
+    STOev,
+    true
+    )
+    MathOptInterface.set(model, MathOptInterface.NLPBlock(), block_data)
+    MathOptInterface.set(model, MathOptInterface.ObjectiveSense(), MathOptInterface.MIN_SENSE)
 
-# Propagate dynamic for new switching times
-propagateDynamics!(STOev, delta0ws)
+    # Propagate dynamic for new switching times
+    propagateDynamics!(STOev, delta0ws)
 
-# Create STO
-STOproblem = linSTO(model, STOev, delta0ws, delta)
-return STOproblem  # Return STO
+    # Create STO
+    STOproblem = linSTO(model, STOev, delta0ws, delta)
+    return STOproblem  # Return STO
 
 end
 
@@ -266,7 +266,7 @@ function stoproblem(
 
   # Generate Model
   model = solver
-  MathOptInterface.empty!(model)
+  #MathOptInterface.empty!(model)
   delta = MathOptInterface.add_variables(model, N+1)
   for i=1:N+1
     MathOptInterface.add_constraint(model, delta[i], MathOptInterface.GreaterThan(lb[i]))

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -358,7 +358,11 @@ function simulateinput(m::nlinSTO, t::Array{Float64, 1})
 
 end
 
-
+function simulateinput(m::nlinSTO, tau::Array{Float64,1}, t::Array{Float64, 1})
+  # u = computenlswinput(m.taucomplete, m.STOev.uvec, t)
+  u = computenlswinput(tau, m.STOev.uvec, t)  # Fix all TAUCOMPLETE
+  return u, t
+end
 
 # Compute Actual Inputs from Artificial Ones
 function computenlswinput(tauopt, uvec, t)

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -2,7 +2,7 @@
 function simulate(m::linSTO)
 
   # Define Time
-  t = collect(linspace(m.STOev.t0, m.STOev.tf, 10000))
+  t = collect(range(m.STOev.t0, stop=m.STOev.tf, length=10000))
 
   # Perform Simulation
   x, xpts, J = simulatelinsto(m.tau, m.STOev.x0, m.STOev.Q, m.STOev.E, m.STOev.A, t)
@@ -14,7 +14,7 @@ end
 function simulate(m::linSTO, tau::Array{Float64,1})
 
   # Define Time
-  t = collect(linspace(m.STOev.t0, m.STOev.tf, 10000))
+  t = collect(range(m.STOev.t0, stop=m.STOev.tf, length=10000))
 
   # Perform Simulation
   x, xpts, J = simulatelinsto(tau, m.STOev.x0, m.STOev.Q, m.STOev.E, m.STOev.A, t)
@@ -42,7 +42,7 @@ end
 function simulate(m::nlinSTO)
 
   # Define Time
-  t = collect(linspace(m.STOev.t0, m.STOev.tf, 10000))
+  t = collect(range(m.STOev.t0, stop=m.STOev.tf, length=10000))
 
   # Get original Q, x0
   Q = m.STOev.Q[1:end-1, 1:end-1]
@@ -61,7 +61,7 @@ end
 function simulate(m::nlinSTO, tau::Array{Float64, 1})
 
   # Define Time
-  t = collect(linspace(m.STOev.t0, m.STOev.tf, 10000))
+  t = collect(range(m.STOev.t0, stop=m.STOev.tf, length=10000))
 
   # Get original, Q, x0
   Q = m.STOev.Q[1:end-1, 1:end-1]
@@ -96,7 +96,7 @@ end
 function simulatelinearized(m::nlinSTO)
 
   # Define Time
-  t = collect(linspace(m.STOev.t0, m.STOev.tf, 10000))
+  t = collect(range(m.STOev.t0, stop=m.STOev.tf, length=10000))
 
   # Get original Q, x0
   Q = m.STOev.Q[1:end-1, 1:end-1]
@@ -104,7 +104,7 @@ function simulatelinearized(m::nlinSTO)
   x0 = m.STOev.x0[1:end-1]
 
   # Perform Simulation
-  x, xpts, J = simulatelinearizedsto(m.STOev.nonlin_dyn, m.STOev.nonlin_dyn_deriv, m.tau, m.STOev.tgrid, m.STOev.tfdelta, m.STOev.uvec,  x0, Q, E,  t)
+  x, xpts, J = simulatelinearizedsto(m.STOev.nonlin_dyn, m.STOev.nonlin_dyn_deriv, m.tau, m.STOev.tgrid, m.STOev.uvec,  x0, Q, E,  t)
 
   return x, xpts, J, t
 
@@ -115,7 +115,7 @@ end
 function simulatelinearized(m::nlinSTO, tau::Array{Float64,1})
 
   # Define Time
-  t = collect(linspace(m.STOev.t0, m.STOev.tf, 10000))
+  t = collect(range(m.STOev.t0, stop=m.STOev.tf, length=10000))
 
   # Get original Q, x0
   Q = m.STOev.Q[1:end-1, 1:end-1]
@@ -159,14 +159,14 @@ function simulatelinsto(tau::Array{Float64,1}, x0::Array{Float64, 1}, Q::Array{F
   tau = [t[1]; tau; t[end]]  # Extend tau vector to simplify numbering
 
   # Compute Initial States
-  xpts = Array{Float64}(nx, N+1)
+  xpts = Array{Float64}(undef, nx, N+1)
   xpts[:,1] = x0
   for i = 2:N+1
-    xpts[:,i] = expm(A[:, :, i-1]*(tau[i] - tau[i-1]))*xpts[:, i-1]
+    xpts[:,i] = exp(A[:, :, i-1]*(tau[i] - tau[i-1]))*xpts[:, i-1]
   end
 
   # Compute State Trajectory
-  x = Array{Float64}(nx, length(t))
+  x = Array{Float64}(undef, nx, length(t))
   x[:, 1] = x0
   tauind = 1  # Index to keep track of the current mode
 
@@ -179,7 +179,7 @@ function simulatelinsto(tau::Array{Float64,1}, x0::Array{Float64, 1}, Q::Array{F
     end
 
     # Compute State
-    x[:, i] = expm(A[:, :, tauind]*(t[i] - tau[tauind]))*xpts[:, tauind]
+    x[:, i] = exp(A[:, :, tauind]*(t[i] - tau[tauind]))*xpts[:, tauind]
 
   end
 
@@ -205,10 +205,10 @@ end
     tvec, tauIdx = mergeSortFindIndex(tgrid, tau)
 
     # Create matrix of Linearized Dynamics
-    A = Array{Float64}(nx+1, nx+1, N+ngrid - 1)
+    A = Array{Float64}(undef, nx+1, nx+1, N+ngrid - 1)
 
     # Compute Initial States
-    xpts = Array{Float64}(nx+1, N+ngrid)  # Augmented State for Linearization
+    xpts = Array{Float64}(undef, nx+1, N+ngrid)  # Augmented State for Linearization
     xpts[:,1] = [x0; 1]
 
 
@@ -228,13 +228,13 @@ end
         A[:,:,i] = linearizeDyn(nonlin_dyn, nonlin_dyn_deriv, xpts[1:end-1,i], uvec[:,uIdx])
 
         # Compute Next Point in Simulation
-        xpts[:,i+1] = expm(A[:, :, i]*(tvec[i+1] - tvec[i]))*xpts[:, i]
+        xpts[:,i+1] = exp(A[:, :, i]*(tvec[i+1] - tvec[i]))*xpts[:, i]
 
       end
 
 
       # Compute State Trajectory
-      x = Array{Float64}(nx+1, length(t))
+      x = Array{Float64}(undef, nx+1, length(t))
       x[:, 1] = [x0; 1]
       tauind = 1  # Index to keep track of the current mode
 
@@ -249,7 +249,7 @@ end
         end
 
         # Compute State
-        x[:, i] = expm(A[:, :, tauind]*(t[i] - tvec[tauind]))*xpts[:, tauind]
+        x[:, i] = exp(A[:, :, tauind]*(t[i] - tvec[tauind]))*xpts[:, tauind]
 
       end
 
@@ -338,7 +338,7 @@ end
 function simulateinput(m::nlinSTO)
 
   # Define Time
-  t = collect(linspace(m.STOev.t0, m.STOev.tf, 10000))
+  t = collect(range(m.STOev.t0, stop=m.STOev.tf, length=10000))
 
 
   # u = computenlswinput(m.taucomplete, m.STOev.uvec, t)
@@ -379,7 +379,7 @@ function computenlswinput(tauopt, uvec, t)
     end
 
     if tempInd2 > tempInd1
-      usim[:, tempInd1:tempInd2] = repmat(uvec[:, i], 1, tempInd2 - tempInd1 + 1)
+      usim[:, tempInd1:tempInd2] = repeat(uvec[:, i], 1, tempInd2 - tempInd1 + 1)
       tempInd1 = tempInd2
     end
 
@@ -392,8 +392,8 @@ end
 
 
 # Trapezoidal integration rule
-function trapz{Tx<:Number, Ty<:Number}(x::Vector{Tx}, y::Vector{Ty})
-    local n = length(x)
+function trapz(x::Vector{Tx}, y::Vector{Ty}) where {Tx <: Number, Ty <: Number}
+  local n = length(x)
     if (length(y) != n)
         error("Vectors 'x', 'y' must be of same length")
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,14 +1,14 @@
 # Empty matrix and vector for function evaluation
-const emptyfvec = Array{Float64}(0)
-const emptyfmat = Array{Float64}(0, 0)
+const emptyfvec = Array{Float64}(undef, 0)
+const emptyfmat = Array{Float64}(undef, 0, 0)
 
 
 # Define Abstract NLP Evaluator for STO problem
-abstract type STOev <: MathProgBase.AbstractNLPEvaluator end
+abstract type STOev <: MathOptInterface.AbstractNLPEvaluator end
 
 
 # Linear Case
-type linSTOev <: STOev
+mutable struct linSTOev <: STOev
   # Parameters
   x0::Array{Float64,1}                    # Initial State x0
   nx::Int                                 # State dimension
@@ -65,7 +65,7 @@ type linSTOev <: STOev
 end
 
 # Nonlinear Case
-type nlinSTOev <: STOev
+mutable struct nlinSTOev <: STOev
   # Parameters
   x0::Array{Float64,1}                     # Initial State x0
   nx::Int                                  # State dimension
@@ -126,35 +126,37 @@ end
 # Create switching time optimization (STO) abstract type
 abstract type STO end
 
-type linSTO <: STO  # Linear STO type
-  model::MathProgBase.AbstractNonlinearModel  # Nonlinear Program Model
+mutable struct linSTO <: STO  # Linear STO type
+  model::MathOptInterface.AbstractOptimizer   # Nonlinear Program Model
   STOev::linSTOev                             # NLP Evaluator for linear STO
 
   # Data Obtained after Optimization
   delta::Array{Float64,1}                     # Optimal Switching Intervals
+  delta_MOI::Array{MathOptInterface.VariableIndex,1}
   tau::Array{Float64,1}                       # Optimal Switching Times
   objval::Float64                             # Optimal Value of Cost Function
-  stat::Symbol                                # Status of Opt Problem
+  stat::MathOptInterface.TerminationStatusCode# Status of Opt Problem
   soltime::Float64                            # Time Required to solve Opt
 
 
   # Inner Contructor for Incomplete Initialization
-  linSTO(model, STOev, delta) = new(model, STOev, delta)
+  linSTO(model, STOev, delta, delta_MOI) = new(model, STOev, delta, delta_MOI)
 
 end
 
-type nlinSTO <: STO  # Nonlinear STO type
-  model::MathProgBase.AbstractNonlinearModel  # Nonlinear Program Model
+mutable struct nlinSTO <: STO  # Nonlinear STO type
+  model::MathOptInterface.AbstractOptimizer  # Nonlinear Program Model
   STOev::nlinSTOev                            # NLP Evaluator for nonlinear STO
 
   # Data Obtained After Optimization
   delta::Array{Float64,1}                     # Optimal Switching Intervals
+  delta_MOI::Array{MathOptInterface.VariableIndex,1}
   tau::Array{Float64,1}                       # Optimal Switching Times
   objval::Float64                             # Optimal Value of Cost Function
-  stat::Symbol                                # Status of Opt Problem
+  stat::MathOptInterface.TerminationStatusCode# Status of Opt Problem
   soltime::Float64                            # Time Required to solve Opt
 
 
   # Inner Contructor for Incomplete Initialization
-  nlinSTO(model, STOev, delta) = new(model, STOev, delta)
+  nlinSTO(model, STOev, delta, delta_MOI) = new(model, STOev, delta, delta_MOI)
 end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,0 @@
-julia 0.5
-BinDeps
-Ipopt

--- a/test/linsys.jl
+++ b/test/linsys.jl
@@ -6,7 +6,7 @@ function linsystest(solver=IpoptSolver(tol=1e-03); objtol = 1e-3, primaltol = 1e
   nx = 2;
 
   # Cost function Matrix
-  Q = eye(2)
+  Q = 1.0 * Matrix(I, nx, nx)
 
   # Initial State
   x0 = [1.0; 1.0]

--- a/test/linsys.jl
+++ b/test/linsys.jl
@@ -1,32 +1,58 @@
-# Test Linear System Optimizaiton withh one switching time
-function linsystest(solver=IpoptSolver(tol=1e-03); objtol = 1e-3, primaltol = 1e-3)
-  println("Testing Switched Linear Systems Optimization ", string(typeof(solver)))
+# Test Linear System Optimizaiton
+using SwitchTimeOpt
+using MathOptInterface
+using LinearAlgebra
+const MOI = MathOptInterface
+using Ipopt
 
-  # Size of the state space
-  nx = 2;
+# Define test options
+objtol = 1e-04
+primaltol = 1e-03
 
-  # Cost function Matrix
-  Q = 1.0 * Matrix(I, nx, nx)
+# Define Solver options
+maxiter = 50
+maxtime = 100.0
+verbose = 0
+tolerance = 1e-06
 
-  # Initial State
-  x0 = [1.0; 1.0]
+#Define solver
+solver = Ipopt.Optimizer()
+MOI.set(solver, MOI.RawOptimizerAttribute("tol"), tolerance)
+MOI.set(solver, MOI.RawOptimizerAttribute("print_level"), verbose)
+MOI.set(solver, MOI.RawOptimizerAttribute("max_cpu_time"), maxtime)
+MOI.set(solver, MOI.RawOptimizerAttribute("max_iter"), maxiter)
 
 
-  # Define initial and final time
-  t0 = 0.0
-  tf = 1.0
 
-  ### Define System Dynamics
-  A = zeros(nx, nx, 2)
-  A[:, :, 1] = [-1 0;
-                1  2]
-  A[:, :, 2] = [1 1;
-                1 -2]
+# Size of the state space
+nx = 2;
 
-  m = stoproblem(x0, A, solver=solver)
-  solve!(m)
+# Cost function Matrix
+Q = 1.0 * Matrix(I, nx, nx)
+
+# Initial State
+x0 = [1.0; 1.0]
+
+
+# Define initial and final time
+t0 = 0.0
+tf = 1.0
+
+### Define System Dynamics
+A = zeros(nx, nx, 2)
+A[:, :, 1] = [-1 0;
+              1  2]
+A[:, :, 2] = [1 1;
+              1 -2]
+
+m = stoproblem(x0, A, solver=solver)
+solve!(m)
+
+@testset "Test optimal switching time" begin 
   @test isapprox(gettau(m)[1], 0.26486646235103123, atol=primaltol)
-  @test isapprox(getobjval(m), 5.2545429449272145, atol=objtol)
+end
 
-  println("Passed")
+@testset "Test status and optimal objective value" begin 
+  @test isapprox(getobjval(m), 5.2545429449272145, atol=objtol)
+  @test string(getstat(m)) == "LOCALLY_SOLVED"
 end

--- a/test/nonlinsys.jl
+++ b/test/nonlinsys.jl
@@ -1,56 +1,79 @@
-# Test Fishing Problem - Switched Nonlinear System
-function nonlinsystest(solver=IpoptSolver(tol=1e-04, max_iter = 25); objtol = 1e-3, primaltol = 1e-3)
-  println("Testing Switched Nonlinear Systems Optimization ", string(typeof(solver)))
+# Test Linear System Optimizaiton
+using SwitchTimeOpt
+using MathOptInterface
+const MOI = MathOptInterface
+using Ipopt
 
-  # Define Time Interval
-  t0 = 0.0; tf = 12.0
+# Define test options
+objtol = 1e-04
+primaltol = 1e-03
 
-  uvec = [repmat([0.0; 1.0], 4, 1); 0.0]'  # Input Vector
+# Define Solver options
+maxiter = 50
+maxtime = 100.0
+verbose = 0
+tolerance = 1e-06
 
-  # Cost Funcction Matrix
-  C = [1.0 0.0 -1.0 0.0;
-       0.0 1.0 0.0  -1.0]
-  Q = C'*C
-
-  # Define Initial State
-  x0 = [0.5; 0.7; 1; 1]
-
-  ### Define System Dynamics
-  function nldyn(x::Array{Float64,1}, u::Array{Float64,1})
-    n = length(x)
-    f = zeros(n)
-    f[1] = x[1] - x[1]*x[2] - 0.4*x[1]*u[1]
-    f[2] = -x[2] + x[1]*x[2] - 0.2*x[2]*u[1]
-    return f
-
-  end
-
-  function nldyn_deriv(x::Array{Float64,1}, u::Array{Float64,1})
-    df = [1.0-x[2]-0.4*u[1]       -x[1]                   0    0;
-          x[2]                     -1+x[1]-0.2*u[1]       0    0;
-          0                        0                      0    0;
-          0                        0                      0    0]
-  end
-
-  m = stoproblem(x0, nldyn, nldyn_deriv, uvec, ngrid = 300, t0=t0, tf=tf, Q=Q, solver=solver)
+#Define solver
+solver = Ipopt.Optimizer()
+MOI.set(solver, MOI.RawOptimizerAttribute("tol"), tolerance)
+MOI.set(solver, MOI.RawOptimizerAttribute("print_level"), verbose)
+MOI.set(solver, MOI.RawOptimizerAttribute("max_cpu_time"), maxtime)
+MOI.set(solver, MOI.RawOptimizerAttribute("max_iter"), maxiter)
 
 
-  solve!(m)
-  # @test getstat(m) == :Optimal
 
-  # Test Optimal Solution
+# Define Time Interval
+t0 = 0.0; tf = 12.0
+
+uvec = [repeat([0.0; 1.0], 4, 1); 0.0]  # Input Vector
+uvec = copy(uvec')
+
+# Cost Funcction Matrix
+C = [1.0 0.0 -1.0;
+      0.0 1.0 -1.0]
+Q = C'*C
+
+# Define Initial State
+x0 = [0.5; 0.7; 1]
+
+### Define System Dynamics
+function nldyn(x::Array{Float64,1}, u::Array{Float64,1})
+  n = length(x)
+  f = zeros(n)
+  f[1] = x[1] - x[1]*x[2] - 0.4*x[1]*u[1]
+  f[2] = -x[2] + x[1]*x[2] - 0.2*x[2]*u[1]
+  return f
+
+end
+
+function nldyn_deriv(x::Array{Float64,1}, u::Array{Float64,1})
+  df = [1.0-x[2]-0.4*u[1]       -x[1]                   0;
+        x[2]                     -1+x[1]-0.2*u[1]       0;
+        0                        0                      0]
+end
+
+m = stoproblem(x0, nldyn, nldyn_deriv, uvec, ngrid = 300, t0=t0, tf=tf, Q=Q, solver=solver)
+
+
+solve!(m)
+
+# Test Optimal Solution
+@testset "Test optimal switching times" begin
   tauopt = gettau(m)
-  @test isapprox(tauopt[1], 2.4434718158206916, atol=primaltol)
-  @test isapprox(tauopt[2], 4.122362522221089, atol=primaltol)
-  @test isapprox(tauopt[3], 4.433072844726073, atol=primaltol)
-  @test isapprox(tauopt[4], 4.68252002334405,  atol=primaltol)
-  @test isapprox(tauopt[5], 5.201667827750571, atol=primaltol)
-  @test isapprox(tauopt[6], 5.369908894975762, atol=primaltol)
-  @test isapprox(tauopt[7], 6.376845190917198, atol=primaltol)
-  @test isapprox(tauopt[8], 6.47160340206027, atol=primaltol)
 
+  @test isapprox(tauopt[1], 2.4435555103155107, atol=primaltol)
+  @test isapprox(tauopt[2], 4.122622390312436, atol=primaltol)
+  @test isapprox(tauopt[3], 4.433725972515174, atol=primaltol)
+  @test isapprox(tauopt[4], 4.682336152264894,  atol=primaltol)
+  @test isapprox(tauopt[5], 5.199622121419033, atol=primaltol)
+  @test isapprox(tauopt[6], 5.367438990179279, atol=primaltol)
+  @test isapprox(tauopt[7], 6.370950931911677, atol=primaltol)
+  @test isapprox(tauopt[8], 6.4660389494043295, atol=primaltol)
+end
+
+@testset "Test status and optimal objective value" begin
   # Test Optimal Value
   @test isapprox(getobjval(m), 1.3454355602054182, atol=objtol)
-
-  println("Passed")
+  @test string(getstat(m)) == "LOCALLY_SOLVED"
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using SwitchTimeOpt
-using Base.Test
+using Test
 using Ipopt
 
 include("linsys.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,4 +3,4 @@ using Test
 using SafeTestsets
 
 @safetestset "Linear system" begin include("./linsys.jl") end
-@safetestset "Noninear system" begin include("./nonlinsys.jl") end
+@safetestset "Nonlinear system" begin include("./nonlinsys.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,6 @@
 using SwitchTimeOpt
 using Test
-using Ipopt
+using SafeTestsets
 
-include("linsys.jl")
-linsystest()
-
-include("nonlinsys.jl")
-nonlinsystest()
+@safetestset "Linear system" begin include("./linsys.jl") end
+@safetestset "Noninear system" begin include("./nonlinsys.jl") end


### PR DESCRIPTION
This updates the code to current versions of Julia (1.6+), and moves away from the deprecated MathProgBase to MathOptInterface.